### PR TITLE
Properly handle scala versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ project/project
 project/target
 target
 .*
+/bin/

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ If you use `SBT <http://www.scala-sbt.org/>`_, build.sbt should look like this:
 
   ...
   autoCompilerPlugins := true
-  addCompilerPlugin("tv.cntt" %% "xgettext" % "1.3")
+  addCompilerPlugin("tv.cntt" % "xgettext" % "1.4-SNAPSHOT" cross CrossVersion.full)
   scalacOptions += "-P:xgettext:xitrum.I18n"
   ...
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,14 @@ name := "xgettext"
 
 version := "1.4-SNAPSHOT"
 
+crossScalaVersions := Seq("2.11.6", "2.11.7", "2.11.8")
+
+crossVersion := CrossVersion.full
+
 // In src/main/scala/scala/Xgettext.scala, see the lines that are marked with
 // "Scala 2.10" and "Scala 2.11".
 //
-// When doing publish-signed, change the version below and those line accordingly.
-scalaVersion := "2.11.4"
-//scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,10 @@ name := "xgettext"
 
 version := "1.4-SNAPSHOT"
 
-crossScalaVersions := Seq("2.11.6", "2.11.7", "2.11.8")
+crossScalaVersions := Seq("2.10.4", "2.10.5", "2.10.6", "2.11.6", "2.11.7", "2.11.8")
 
 crossVersion := CrossVersion.full
 
-// In src/main/scala/scala/Xgettext.scala, see the lines that are marked with
-// "Scala 2.10" and "Scala 2.11".
-//
 scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
@@ -21,6 +18,9 @@ scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 // java.lang.UnsupportedClassVersionError: Unsupported major.minor version 51.0
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 
-libraryDependencies <+= scalaVersion { sv =>
-  "org.scala-lang" % "scala-compiler" % sv
-}
+libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+
+unmanagedSourceDirectories in Compile += baseDirectory.value / (scalaBinaryVersion.value match {
+  case "2.10" => "src/main/scala-2_10"
+  case _      => "src/main/scala-2_11"
+})

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Run sbt/sbt eclipse to create Eclipse project file
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
 
 // Run sbt/sbt gen-idea to create IntelliJ project file
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/src/main/scala-2_10/scala/ScalaVersionAdapter.scala
+++ b/src/main/scala-2_10/scala/ScalaVersionAdapter.scala
@@ -1,0 +1,15 @@
+package scala
+
+import scala.tools.nsc.Global
+
+/**
+ * Adapter for hiding differences between major Scala versions
+ */
+trait ScalaVersionAdapter {
+  protected val global: Global
+  import global._
+
+  protected final def getTypeFor(typeName: String) = {
+    rootMirror.getClassByName(stringToTypeName(typeName)).tpe
+  }
+}

--- a/src/main/scala-2_11/scala/ScalaVersionAdapter.scala
+++ b/src/main/scala-2_11/scala/ScalaVersionAdapter.scala
@@ -1,0 +1,15 @@
+package scala
+
+import scala.tools.nsc.Global
+
+/**
+ * Adapter for hiding differences between major Scala versions
+ */
+trait ScalaVersionAdapter {
+  protected val global: Global
+  import global._
+
+  protected final def getTypeFor(typeName: String) = {
+    rootMirror.getClassByName(TypeName(typeName)).tpe
+  }
+}

--- a/src/main/scala/scala/Xgettext.scala
+++ b/src/main/scala/scala/Xgettext.scala
@@ -10,7 +10,7 @@ import nsc.plugins.Plugin
 import nsc.plugins.PluginComponent
 
 // http://www.scala-lang.org/node/140
-class Xgettext(val global: Global) extends Plugin {
+class Xgettext(val global: Global) extends Plugin with ScalaVersionAdapter {
   import global._
 
   type i18nKey = (
@@ -98,11 +98,7 @@ msgstr ""
       def apply(unit: CompilationUnit) {
         val shouldExtract = !i18n_class.isEmpty && emptyOutputFileExists
         if (shouldExtract) {
-          // Scala 2.10:
-          //val i18nType = rootMirror.getClassByName(stringToTypeName(i18n_class)).tpe
-
-          // Scala 2.11:
-          val i18nType = rootMirror.getClassByName(TypeName(i18n_class)).tpe
+          val i18nType = getTypeFor(i18n_class)
 
           for (tree @ Apply(Select(x1, x2), list) <- unit.body) {
             if (x1.tpe <:< i18nType) {


### PR DESCRIPTION
This PR takes care of two issues:

- The compiler API is not guarantied to be stable, even between minor releases of Scala. Artifacts should therefore be published with the full Scala version.
- The project is now cross compiled properly for different Scala versions. Manual modifications to handle incompatibilities between Scala-2.10 and Scala-2.11 are no longer necessary. 