### PR TITLE
scala-xgettext cannot handle double quotes in strings and newlines

### DIFF
--- a/src/main/scala/scala/Xgettext.scala
+++ b/src/main/scala/scala/Xgettext.scala
@@ -178,12 +178,13 @@ msgstr ""
        * we should change it to just "Don't go".
        */
       private def fixQuotesAndNewlines(s: String): String = {
-        s.replaceAllLiterally("""\'""", "'")
-        s.replaceAllLiterally("""\"""", """"""")
+        val escapedSingleQuotes = s.replaceAllLiterally("""\'""", "'")
+        val escapedDoubleQuotes = escapedSingleQuotes.substring(1, s.length - 1).replaceAllLiterally("\"", "\\\"")
+        val escapedS = escapedSingleQuotes(0) + escapedDoubleQuotes + escapedSingleQuotes(escapedSingleQuotes.length - 1)
 
-        val lines = s.split("\n")
+        val lines = escapedDoubleQuotes.split("\n", -1)
         if(lines.length == 1)
-          return s""""$s"""" // If there are no new lines the potFormat is simply "$string"
+          return escapedS // If there are no new lines the potFormat is simply "$string"
         val literalTwoDoubleQuotes = """""""" // The string literal ""
 
         // multi line format for .pot files:

--- a/src/main/scala/scala/Xgettext.scala
+++ b/src/main/scala/scala/Xgettext.scala
@@ -132,24 +132,24 @@ msgstr ""
 
               if (i18n_t.contains(methodName)) {
                 for (msgid <- stringConstant(list.head, pos)) {
-                  msgToLines.addBinding((None, fixBackslashSingleQuote(msgid), None), line)
+                  msgToLines.addBinding((None, fixQuotesAndNewlines(msgid), None), line)
                 }
               } else if (i18n_tn.contains(methodName)) {
                 for (msgid <- stringConstant(list.head, pos);
                      msgidPlural <- stringConstant(list(1), pos)) {
-                  msgToLines.addBinding((None, fixBackslashSingleQuote(msgid), Some(fixBackslashSingleQuote(msgidPlural))), line)
+                  msgToLines.addBinding((None, fixQuotesAndNewlines(msgid), Some(fixQuotesAndNewlines(msgidPlural))), line)
                 }
               } else if (i18n_tc.contains(methodName)) {
                 for (msgctxt <- stringConstant(list.head, pos);
                      msgid <- stringConstant(list(1), pos)) {
-                  msgToLines.addBinding((Some(fixBackslashSingleQuote(msgctxt)), fixBackslashSingleQuote(msgid), None), line)
+                  msgToLines.addBinding((Some(fixQuotesAndNewlines(msgctxt)), fixQuotesAndNewlines(msgid), None), line)
                 }
               } else if (i18n_tcn.contains(methodName)) {
                 for (msgctxt <- stringConstant(list.head, pos);
                      msgid <- stringConstant(list(1), pos);
                      msgidPlural <- stringConstant(list(2), pos)) {
-                  msgToLines.addBinding((Some(fixBackslashSingleQuote(msgctxt)), fixBackslashSingleQuote(msgid),
-                    Some(fixBackslashSingleQuote(msgidPlural))), line)
+                  msgToLines.addBinding((Some(fixQuotesAndNewlines(msgctxt)), fixQuotesAndNewlines(msgid),
+                    Some(fixQuotesAndNewlines(msgidPlural))), line)
                 }
               }
             }
@@ -177,8 +177,23 @@ msgstr ""
        * Poedit will report "invalid control sequence" for key "Don\'t go", so
        * we should change it to just "Don't go".
        */
-      private def fixBackslashSingleQuote(s: String): String = {
+      private def fixQuotesAndNewlines(s: String): String = {
         s.replaceAllLiterally("""\'""", "'")
+        s.replaceAllLiterally("""\"""", """"""")
+
+        val lines = s.split("\n")
+        if(lines.length == 1)
+          return s""""$s"""" // If there are no new lines the potFormat is simply "$string"
+        val literalTwoDoubleQuotes = """""""" // The string literal ""
+
+        // multi line format for .pot files:
+        // lines == List("bar", "foo") =>
+        // ""
+        // "bar\n"
+        // "foo"
+        val potFormattedNewLines = lines.mkString("\"", "\\n\"\n\"", "\"")
+
+        literalTwoDoubleQuotes + "\n" + potFormattedNewLines
       }
     }
   }

--- a/src/main/scala/scala/Xgettext.scala
+++ b/src/main/scala/scala/Xgettext.scala
@@ -196,7 +196,7 @@ msgstr ""
 
       // Replace \' with '
       private val unEscapeSingleQuote: String => String = s => {
-        s.replaceAll("\\'", "'")
+        s.replaceAllLiterally("\\'", "'")
       }
 
       // Replace " with \"

--- a/src/main/scala/scala/Xgettext.scala
+++ b/src/main/scala/scala/Xgettext.scala
@@ -186,12 +186,7 @@ msgstr ""
         * "foo"
        */
       private def formatString(s: String): String = {
-        List(unEscapeSingleQuote, escapeDoubleQuote, mkXgettextNewlines).foldLeft(s)((v, f) => {
-          if (v.contains("Marcus")){
-            println(v)
-          }
-          f(v)
-        })
+        List(unEscapeSingleQuote, escapeDoubleQuote, mkXgettextNewlines).foldLeft(s)((v, f) => f(v))
       }
 
       // Replace \' with '


### PR DESCRIPTION
Fixed 2 bugs regarding:
- scala-xgettext cannot handle ( " ) in string - these must be escaped
- scala-xgettext does not correctly handle multiline strings, so you need to build these yourselves:
List(
  I18n.tc("Example", "How are you doing"),
  I18n.n,
  I18n.tc("Example", "I am doing great!")
).merge
I have changed this such that "foo\n bar" ->
""
"foo\n"
"bar" 
cf. xgettext syntax 